### PR TITLE
mars-gen: Improve templates, format sources before writing to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased](https://github.com/roblillack/mars/compare/v1.0.4...master)
 
 - Add unit test for `cert`.
+- Improve code generation to not write redundant type information. #20
 
 ## [v1.0.4](https://github.com/roblillack/mars/compare/v1.0.3...v1.0.4)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 build: off
 
-stack: go 1.14
+stack: go 1.16
 
 before_test:
   - go vet ./...

--- a/cmd/mars-gen/main.go
+++ b/cmd/mars-gen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/format"
 	"os"
 	"path"
 	"text/template"
@@ -121,7 +122,12 @@ func generateSources(tpl, filename string, templateArgs map[string]interface{}) 
 	}
 	defer file.Close()
 
-	if _, err := file.WriteString(sourceCode); err != nil {
+	formatted, err := format.Source([]byte(sourceCode))
+	if err != nil {
+		fatalf("Failed to format file: %v", err)
+	}
+
+	if _, err := file.Write(formatted); err != nil {
 		fatalf("Failed to write to file: %v", err)
 	}
 }
@@ -144,10 +150,10 @@ func {{.functionName}}() {
 	{{range $i, $c := .controllers}}
 	mars.RegisterController((*{{.StructName}})(nil),
 		[]*mars.MethodType{
-			{{range .MethodSpecs}}&mars.MethodType{
+			{{range .MethodSpecs}}{
 				Name: "{{.Name}}",
 				Args: []*mars.MethodArg{ {{range .Args}}
-					&mars.MethodArg{Name: "{{.Name}}", Type: reflect.TypeOf((*{{index $.ImportPaths .ImportPath | .TypeExpr.TypeName}})(nil)) },{{end}}
+					{Name: "{{.Name}}", Type: reflect.TypeOf((*{{index $.ImportPaths .ImportPath | .TypeExpr.TypeName}})(nil)) },{{end}}
 				},
 			},
 			{{end}}


### PR DESCRIPTION
This changeset improves the quality of generated sources in that unnecessary type declarations are skipped and the resulting output is formatted using the [standard Go formatter](https://pkg.go.dev/go/format), too.

Ticket: #20